### PR TITLE
Required php5enmod command added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update && apt-get install -y \
     php5-curl \
     php5-mcrypt 
 
+RUN sudo php5enmod mcrypt
+
 RUN git clone https://github.com/aajanki/yle-dl.git && \
     cd yle-dl && \
     make install


### PR DESCRIPTION
Yle-dl now requires to run php5enmod on Ubuntu:
https://github.com/aajanki/yle-dl/commit/02b3d9d7529c37a97c35cb07c3463dfbb80ea3d8

Couldn't run newest version of yle-dl without this but after adding this everything worked just fine.